### PR TITLE
Reissue certificate if domains change

### DIFF
--- a/cmd/certificator/main.go
+++ b/cmd/certificator/main.go
@@ -65,14 +65,14 @@ func main() {
 		}
 		logger.Infof("checking certificate for %s", mainDomain)
 
-		needsRenewing, err := certificate.NeedsRenewing(cert, mainDomain, cfg.RenewBeforeDays, logger)
+		needsReissuing, err := certificate.NeedsReissuing(cert, allDomains, cfg.RenewBeforeDays, logger)
 		if err != nil {
 			failedDomains = append(failedDomains, mainDomain)
 			logger.Error(err)
 			continue
 		}
 
-		if needsRenewing {
+		if needsReissuing {
 			logger.Infof("obtaining certificate for %s", mainDomain)
 			err := certificate.ObtainCertificate(acmeClient, vaultClient, allDomains,
 				cfg.DNSAddress, cfg.Acme.DNSChallengeProvider, cfg.Acme.DNSPropagationRequirement)


### PR DESCRIPTION
Currently, if we change alternative names of a certificate certificator does not reissue the certificates. It checks only if the certificate exists and is valid for more than configured validity days.

After this change, it will check for what domains the certificate was issued and if that changes it will reissue the certificate.
