### PR TITLE
customizable in hashicorp vault field

### DIFF
--- a/cmd/certificator/main.go
+++ b/cmd/certificator/main.go
@@ -75,7 +75,7 @@ func main() {
 		if needsReissuing {
 			logger.Infof("obtaining certificate for %s", mainDomain)
 			err := certificate.ObtainCertificate(acmeClient, vaultClient, allDomains,
-				cfg.DNSAddress, cfg.Acme.DNSChallengeProvider, cfg.Acme.DNSPropagationRequirement)
+				cfg.DNSAddress, cfg.Acme.DNSChallengeProvider, cfg.Acme.DNSPropagationRequirement, &cfg)
 			if err != nil {
 				failedDomains = append(failedDomains, mainDomain)
 				logger.Error(err)

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -11,12 +11,13 @@ import (
 	"github.com/go-acme/lego/v4/lego"
 	"github.com/go-acme/lego/v4/providers/dns"
 	"github.com/sirupsen/logrus"
+	"github.com/vinted/certificator/pkg/config"
 	"github.com/vinted/certificator/pkg/vault"
 )
 
 // ObtainCertificate gets certificate and stores it in Vault KV store
 func ObtainCertificate(client *lego.Client, vault *vault.VaultClient, domains []string,
-	dnsAddr, challengeProvider string, propagationReq bool) error {
+	dnsAddr, challengeProvider string, propagationReq bool, cfg *config.Config) error {
 	provider, err := dns.NewDNSChallengeProviderByName(challengeProvider)
 	if err != nil {
 		return err
@@ -43,7 +44,7 @@ func ObtainCertificate(client *lego.Client, vault *vault.VaultClient, domains []
 		return err
 	}
 
-	return storeCertificateInVault(domains[0], certificate, vault)
+	return storeCertificateInVault(domains[0], certificate, vault, cfg)
 }
 
 // GetCertificate reads certificate from Vault KV store and parses it
@@ -120,10 +121,11 @@ func vaultCertLocation(domain string) string {
 	return "certificates/" + domain
 }
 
-func storeCertificateInVault(domain string, certs *certificate.Resource, vault *vault.VaultClient) error {
-	payload := map[string]string{"certificate": string(certs.Certificate),
-		"private_key":        string(certs.PrivateKey),
-		"issuer_certificate": string(certs.IssuerCertificate)}
-
+func storeCertificateInVault(domain string, certs *certificate.Resource, vault *vault.VaultClient, cfg *config.Config) error {
+	payload := map[string]string{
+		cfg.CertificateFieldName:       string(certs.Certificate),
+		cfg.PrivateKeyFieldName:        string(certs.PrivateKey),
+		cfg.IssuerCertificateFieldName: string(certs.IssuerCertificate),
+	}
 	return vault.KVWrite(vaultCertLocation(domain), payload)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,14 +32,17 @@ type Log struct {
 
 // Config contains all configuration parameters
 type Config struct {
-	Acme            Acme
-	Vault           Vault
-	Log             Log
-	DNSAddress      string   `envconfig:"DNS_ADDRESS" default:"127.0.0.1:53"`
-	Environment     string   `envconfig:"ENVIRONMENT" default:"prod"`
-	DomainsFile     string   `envconfig:"CERTIFICATOR_DOMAINS_FILE" default:"/code/domains.yml"`
-	RenewBeforeDays int      `envconfig:"CERTIFICATOR_RENEW_BEFORE_DAYS" default:"30"`
-	Domains         []string `yaml:"domains"`
+	Acme                       Acme
+	Vault                      Vault
+	Log                        Log
+	DNSAddress                 string   `envconfig:"DNS_ADDRESS" default:"127.0.0.1:53"`
+	Environment                string   `envconfig:"ENVIRONMENT" default:"prod"`
+	DomainsFile                string   `envconfig:"CERTIFICATOR_DOMAINS_FILE" default:"/code/domains.yml"`
+	RenewBeforeDays            int      `envconfig:"CERTIFICATOR_RENEW_BEFORE_DAYS" default:"30"`
+	CertificateFieldName       string   `envconfig:"CERTIFICATE_FIELD_NAME" default:"certificate"`
+	PrivateKeyFieldName        string   `envconfig:"PRIVATE_KEY_FIELD_NAME" default:"private_key"`
+	IssuerCertificateFieldName string   `envconfig:"ISSUER_CERTIFICATE_FIELD_NAME" default:"issuer_certificate"`
+	Domains                    []string `yaml:"domains"`
 }
 
 // LoadConfig loads configuration options to  variable


### PR DESCRIPTION
hi, I added the ability to set field names in the hashicorp vault key via environment variables CERTIFICATE_FIELD_NAME, PRIVATE_KEY_FIELD_NAME, ISSUER_CERTIFICATE_FIELD_NAME. This is necessary for the vault secrets operator.

Below is the log from the vault secrets operator to understand the context.

```
Name:         vault-static-secret-v3
Namespace:    nginx-ingress
API Version:  secrets.hashicorp.com/v1beta1
Kind:         VaultStaticSecret
Creation Timestamp:  2025-04-10T10:36:40Z
Spec:
  Destination:
    Create:          true
    Name:            static-secret2
    Overwrite:       false
    Type:            kubernetes.io/tls
  Hmac Secret Data:  true
  Mount:             kv
  Path:              azaza/infra/security/x.509/certificates/k8s-qa-test.azaza.space
  Refresh After:     60s
  Type:              kv-v2
  Vault Auth Ref:    vault-auth
  Version:           2
Events:
  Warning  Unrecoverable           Failed to get cacheKey from obj, err=ServiceAccount "vault" not found
  Warning  VaultClientConfigError  Failed to get Vault auth login: ServiceAccount "vault" not found
  Warning  SecretSyncError         Failed to update k8s secret: Secret "static-secret2" is invalid: [data[tls.crt]: Required value, data[tls.key]: Required value]

```