### PR TITLE
Adding support for Vault JWT Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Configuration variables:
 - `ACME_DNS_PROPAGATION_REQUIREMENT` - if set to true, requires complete DNS record propagation before stating that challenge is solved. Default: true
 - `ACME_REREGISTER_ACCOUNT` - if set to true, allows registering an account with CA. This should be set to true for the first use. When credentials are stored in Vault, you can set this to false to avoid accidental registrations. Default: false
 - `ACME_SERVER_URL` - ACME directory location. Default: https://acme-staging-v02.api.letsencrypt.org/directory
-- `VAULT_APPROLE_ROLE_ID` - role ID for Vault approle authentication method. **Required in prod env**
-- `VAULT_APPROLE_SECRET_ID` - secret ID for Vault approle authentication method. **Required in prod env**
+- `VAULT_APPROLE_ROLE_ID` - role ID for Vault approle authentication method. **Required in prod env if VAULT_TOKEN is not set**
+- `VAULT_APPROLE_SECRET_ID` - secret ID for Vault approle authentication method. **Required in prod env if VAULT_TOKEN is not set**
+- `VAULT_TOKEN` - token for Vault JWT authentication method - if set, use the JWT auth method with this token to authenticate against Vault.
 - `VAULT_KV_STORAGE_PATH` - path in Vault KV storage where certificator stores certificates and account data. Default: secret/data/certificator/
 - `VAULT_ADDR` sets vault address, example: "http://localhost:8200". **Required**
 - `LOG_FORMAT` - logging format, supported formats - JSON and LOGFMT. Default: JSON

--- a/cmd/certificator/main.go
+++ b/cmd/certificator/main.go
@@ -40,8 +40,7 @@ func main() {
 		logger.SetLevel(logrus.FatalLevel)
 	}
 
-	vaultClient, err := vault.NewVaultClient(cfg.Vault.ApproleRoleID,
-		cfg.Vault.ApproleSecretID, cfg.Environment, cfg.Vault.KVStoragePath, logger)
+	vaultClient, err := vault.NewVaultClient(cfg.Vault, cfg.Environment, logger)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,7 @@ type Acme struct {
 type Vault struct {
 	ApproleRoleID   string `envconfig:"VAULT_APPROLE_ROLE_ID"`
 	ApproleSecretID string `envconfig:"VAULT_APPROLE_SECRET_ID"`
+	Token           string `envconfig:"VAULT_TOKEN"`
 	KVStoragePath   string `envconfig:"VAULT_KV_STORAGE_PATH" default:"secret/data/certificator/"`
 }
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/testutil"
 	"github.com/vinted/certificator/pkg/acme"
 	"github.com/vinted/certificator/pkg/certificate"
+	"github.com/vinted/certificator/pkg/config"
 	"github.com/vinted/certificator/pkg/vault"
 )
 
@@ -48,7 +49,8 @@ func TestAcmeClientAndAccountSetup(t *testing.T) {
 	// Make sure that this variable provides access to vault KV storage
 	testVaultClient.SetToken(vaultDevToken)
 
-	vaultClient, err := vault.NewVaultClient("", "", "dev", vaultKVPath, logger)
+	vaultCfg := config.Vault{KVStoragePath: vaultKVPath}
+	vaultClient, err := vault.NewVaultClient(vaultCfg, "dev", logger)
 	testutil.Ok(t, err)
 
 	// Make sure we are starting in a clean Vault
@@ -146,7 +148,8 @@ func TestCertificateObtaining(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.WarnLevel)
 
-	vaultClient, err := vault.NewVaultClient("", "", "dev", vaultKVPath, logger)
+	vaultCfg := config.Vault{KVStoragePath: vaultKVPath}
+	vaultClient, err := vault.NewVaultClient(vaultCfg, "dev", logger)
 	testutil.Ok(t, err)
 
 	acmeClient, err := acme.NewClient(acmeEmail, acmeURL, true, vaultClient, logger)


### PR DESCRIPTION
This adds Vault [JWT Authentication](https://developer.hashicorp.com/vault/docs/auth/jwt#jwt-authentication) support, which is an alternative to approle authentication. When `VAULT_TOKEN` is set, `VAULT_APPROLE_ROLE_ID` and `VAULT_APPROLE_SECRET_ID` do not need to be set. Note that this PR has conflicts with #10, specifically in `test/integration_test.go` - once one is merged the other will need to be updated.

As per #9 and #10, this is work done for a client that I'm now offering upstream 🙂